### PR TITLE
fix(security): pin Trufflehog version to avoid parameter error on main

### DIFF
--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.31.2
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
@main tag currently fails on an unknown argument '--github-actions'.
Pin the version to avoid it, and we will use Renovate to keep
up-to-date.